### PR TITLE
Fix math misdetection of hyphenated text and relative log path

### DIFF
--- a/application/sustain.py
+++ b/application/sustain.py
@@ -18,7 +18,8 @@ from word2number import w2n
 
 # Configure logging
 logging.basicConfig(
-    filename='../sustain.log',
+    filename=os.path.abspath(os.path.join(
+        os.path.dirname(__file__), '..', 'sustain.log')),
     level=logging.INFO,
     format='%(asctime)s - %(levelname)s - %(message)s'
 )
@@ -245,7 +246,12 @@ class SUSTAIN:
     def answer_math(self, user_input):
         """Answer math queries directly without calling the API."""
         if self.math_optimizer.recognize_math(user_input):
-            return self.math_optimizer.solve_math(user_input)
+            result = self.math_optimizer.solve_math(user_input)
+            # Fall back to the API for inputs that only looked like math
+            # (e.g. hyphenated words such as "state-of-the-art")
+            if result == "Error: Invalid math expression":
+                return None
+            return result
         return None
 
     def get_response(self, user_input):

--- a/application/sustain.py
+++ b/application/sustain.py
@@ -128,8 +128,12 @@ class MathOptimizer:
             if re.match(r'^[\d+\-*/(). ]+$', user_input):
                 return self._safe_eval(user_input)
             return "Error: Invalid math expression"
-        except (SyntaxError, ValueError, ZeroDivisionError, OverflowError) as e:
+        except (ZeroDivisionError, OverflowError) as e:
+            # Genuine runtime math errors are reported directly
             return f"Error: {str(e)}"
+        except (SyntaxError, ValueError):
+            # Parse/validation failure: the input only looked like math
+            return "Error: Invalid math expression"
 
     def _safe_eval(self, expr):
         """Safely evaluate mathematical expressions using AST."""


### PR DESCRIPTION
## Testing summary

- Created a fresh venv, installed `requirements.txt`, and downloaded the `en_core_web_sm` spaCy model.
- Compile-checked all sources under `application/` with `py_compile` (clean).
- Exercised `MathOptimizer`, `TextOptimizer`, and `SUSTAIN` helpers with normal and edge-case inputs: simple arithmetic (`2+2`, `((2+3)*4)`), word math (`five plus three`, `2 to the power of 3`), division by zero, empty/whitespace input, hyphenated natural-language text, and token-savings percentage edge cases (zero/negative deltas).
- GUI (`tkinter`) and live OpenAI calls were not exercised in this headless environment without an API key.

## Bugs found and fixed

1. **Hyphenated text misdetected as math.** `recognize_math` matches `\w+-\w+`, so inputs like "what is a state-of-the-art model" or "tell me about well-known facts" were routed to the math solver and returned `Error: Invalid math expression` to the user instead of an AI answer. `answer_math` now falls back to the API when the recognized "math" fails to parse, while genuine math errors (e.g. division by zero) are still reported directly.

2. **Log file written relative to the current working directory.** `sustain.py` configured logging with `filename='../sustain.log'`, so importing the module from any other working directory wrote `sustain.log` to an arbitrary location (verified: it created a log file at filesystem root when imported from `/tmp`). The path is now resolved relative to the module, matching the approach already used in `main.py`.

https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5)_